### PR TITLE
Mayhem Integration

### DIFF
--- a/.github/workflows/mayhem.yml
+++ b/.github/workflows/mayhem.yml
@@ -1,0 +1,64 @@
+name: Mayhem
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  workflow_call:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    name: ${{ matrix.os }} shared=${{ matrix.shared }} ${{ matrix.build_type }}
+    runs-on: ${{ matrix.os }}
+    permissions:
+      packages: write
+      contents: write
+      security-events: write
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        shared: [false]
+        build_type: [Release]
+        include:
+          - os: ubuntu-latest
+            triplet: x64-linux
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Start analysis
+        uses: ForAllSecure/mcode-action@v1
+        with:
+          mayhem-token: ${{ secrets.MAYHEM_TOKEN }}
+          args: --image ${{ steps.meta.outputs.tags }} --duration 300
+          sarif-output: sarif
+
+      - name: Upload SARIF file(s)
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: sarif

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# FROM rust:latest as builder
+# RUN rustup toolchain install nightly && cargo install cargo-fuzz
+# COPY . /bnf/
+# WORKDIR /bnf/fuzz
+# RUN cargo +nightly fuzz build
+
+# FROM debian:bullseye-slim
+# COPY --from=builder /bnf/fuzz/target/x86_64-unknown-linux-gnu/release/ .
+
+FROM rust:latest as builder
+# RUN rustup toolchain install nightly && cargo install cargo-fuzz
+COPY . /bnf/
+WORKDIR /bnf/fuzzing
+RUN cargo build
+
+FROM debian:bullseye-slim
+COPY --from=builder /bnf/fuzzing/target/debug .

--- a/Mayhemfile
+++ b/Mayhemfile
@@ -1,0 +1,9 @@
+project: bnf
+target: bnf
+
+image: ghcr.io/ebell495/bnf:latest
+duration: 300
+tests: null
+
+cmds:
+    - cmd: ./fuzzing @@

--- a/fuzzing/Cargo.toml
+++ b/fuzzing/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "fuzzing"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+#[dependencies]
+[dependencies.bnf]
+path = ".."

--- a/fuzzing/src/main.rs
+++ b/fuzzing/src/main.rs
@@ -1,0 +1,15 @@
+use bnf::Grammar;
+use std::env;
+use std::fs;
+
+fn main() {
+    // println!("Hello, world!");
+    let args: Vec<String> = env::args().collect();
+    let filename = &args[1];
+    let contents = fs::read_to_string(filename)
+        .expect("Something went wrong reading the file");
+    
+    let grammar: Grammar = contents.parse().unwrap();
+    let sentence = grammar.generate().unwrap();
+    println!("{}", sentence);
+}


### PR DESCRIPTION
Added Dockerfile, Mayhemfile, Fuzzing target and the Mayhem workflow

Added a Mayhem workflow to handle fuzzing the application. The fuzzing target takes a file, reads the file, then uses BNF to both parse the grammar and generate sentences from the grammar. Doing both provides the fuzzer more code paths to analyze and better code coverage.
